### PR TITLE
Support CORS-enabled images with crossOrigin option

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,13 @@ Default: `undefined`
 
 Canvas implementation to be used to allow usage outside of the browser. e.g Node.js with node-canvas.
 
+##### options.crossOrigin
+
+Type: `string`<br>
+Default: `undefined`
+
+The `crossOrigin` attribute that `Image` instances should use. e.g `Anonymous` to [support CORS-enabled images](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image).
+
 ## License
 
 MIT © Luke Childs

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,7 @@ const mergeImages = (sources = [], options = {}) => new Promise(resolve => {
 		img.onerror = () => reject(new Error('Couldn\'t load image'));
 		img.onload = () => resolve(Object.assign({}, source, { img }));
 		img.src = source.src;
+		img.crossOrigin = options.crossOrigin;
 	}));
 
 	// Get canvas context

--- a/src/index.js
+++ b/src/index.js
@@ -27,10 +27,10 @@ const mergeImages = (sources = [], options = {}) => new Promise(resolve => {
 
 		// Resolve source and img when loaded
 		const img = new Image();
+		img.crossOrigin = options.crossOrigin;
 		img.onerror = () => reject(new Error('Couldn\'t load image'));
 		img.onload = () => resolve(Object.assign({}, source, { img }));
 		img.src = source.src;
-		img.crossOrigin = options.crossOrigin;
 	}));
 
 	// Get canvas context

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,8 @@ const defaultOptions = {
 	quality: 0.92,
 	width: undefined,
 	height: undefined,
-	Canvas: undefined
+	Canvas: undefined,
+	crossOrigin: undefined
 };
 
 // Return Promise


### PR DESCRIPTION
This branch introduces a `crossOrigin` option that is undefined by default, but can be set to `Anonymous` in order to allow cross-origin images to be loaded from servers that support CORS.

I used the method described at https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image as inspiration for this change.

Fixes #54 
Fixes #80 